### PR TITLE
Add regression test for Copy-on-Write solve_model no-op

### DIFF
--- a/tests/test_model_solver.py
+++ b/tests/test_model_solver.py
@@ -105,6 +105,38 @@ def test_solve_model(
         assert solution[col].tolist() == pytest.approx(values, rel=TOLERANCE)
 
 
+# Regression test for the Copy-on-Write no-op bug (pandas >= 3.0)
+@pytest.mark.parametrize("force_single_block", [False, True])
+def test_solve_model_writes_back_under_cow(force_single_block: bool) -> None:
+    """solve_model must return solved endogenous values, not the initial guesses.
+
+    Under pandas >= 3.0 Copy-on-Write, DataFrame.to_numpy() no longer aliases
+    the DataFrame, so the solver works on a detached copy. Without an explicit
+    write-back this silently dropped all results on a multi-block frame
+    (returning the initial guesses unchanged) or raised "assignment destination
+    is read-only" on a single-block frame. The assertions below are
+    layout-agnostic so both variants are guarded.
+    """
+    model = ms.ModelSolver(["x = a", "y = x + b"], ["x", "y"])
+
+    df = pd.DataFrame(
+        {
+            "a": [10.0, 20.0, 30.0],
+            "b": [1, 2, 3],  # int -> multi-block frame by default
+            "x": [999.0, 999.0, 999.0],  # deliberately wrong initial guesses
+            "y": [999.0, 999.0, 999.0],
+        }
+    )
+    if force_single_block:
+        # Consolidate into a single float block (to_numpy() returns a read-only view)
+        df = pd.DataFrame(df.to_numpy(dtype=float), columns=df.columns)
+
+    sol = model.solve_model(df)
+
+    np.testing.assert_allclose(sol["x"].to_numpy(), [10.0, 20.0, 30.0])
+    np.testing.assert_allclose(sol["y"].to_numpy(), [11.0, 22.0, 33.0])
+
+
 # Test switching endogenous variables
 def test_switch_endo_vars(equations: list[str], endogenous: list[str]) -> None:
     model = ms.ModelSolver(equations, endogenous)


### PR DESCRIPTION
## Summary

A bugfix note (`model_solver-cow-bugfix-note.md`) documented a **silent no-op** in `ModelSolver.solve_model` under **pandas ≥ 3.0** (Copy-on-Write): `DataFrame.to_numpy()` no longer returns a writable view aliasing the DataFrame, so the solver wrote results into a detached array that was never reflected in the returned frame.

I double-checked the cause against the current code and pandas **3.0.3** / numpy **2.4.0** / Python **3.14**:

- **The cause in the note is accurate.** On a multi-block frame `to_numpy()` returns a detached copy → solver writes are discarded (no error, endogenous vars keep their guesses). On a single consolidated float block it returns a read-only view → in-place writes raise `assignment destination is read-only`.
- **The production fix already landed on `main`** (commits `695376c` and `41150bb`): `copy=True` on the `to_numpy()` calls in `solve_model` and `sensitivity`, plus an explicit `output_df.iloc[:, :] = output_array` write-back before returning. I verified both reproduction cases from the note now pass (`x = [10, 20, 30]`, `y = [11, 22, 33]`, no error) — the in-place `.iloc[:, :]` write-back is functionally equivalent to the note's `pd.DataFrame(...)` rebuild, so the working production code was left untouched to avoid needless churn.
- **The one outstanding checklist item was the regression test**, which did not exist. This PR adds it.

## Changes

- Add `test_solve_model_writes_back_under_cow`, parametrized over multi-block and single-block (consolidated) input, asserting that solved endogenous values — not the initial guesses — are returned. The assertions are layout-agnostic, so the test guards both the silent-no-op and read-only-crash variants.

## Verification

- Full suite: **14 passed** on pandas 3.0.3 / numpy 2.4.0 / Python 3.14.
- Confirmed the new test is meaningful: temporarily removing the `output_df.iloc[:, :] = output_array` write-back makes **both** parametrizations fail; restoring it makes them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)